### PR TITLE
Updated to work with recent Express. mu2.root is set

### DIFF
--- a/mu2Express.js
+++ b/mu2Express.js
@@ -1,11 +1,22 @@
-var mu2 = require('mu2');
+var mu2 = require('mu2'),
+	path = require('path');
+
 /**
  * MU2 render function
  */
-var mustacheEngine = function(path, options, fn) {
+var mustacheEngine = function(filename, options, fn) {
+	// Set mustache root dir, so it can find partials.
+	if ((typeof options.settings === 'object') && options.settings.views) {
+		// Use the views directory from Express.
+		mu2.root = options.settings.views;
+	}
+	else {
+		// Use the directory where current file is.
+		mu2.root = path.dirname(filename);
+	}
+
 	var result = "";
-	var view  = options.locals || {};
-	mu2.compileAndRender(path, view).on('data', function(data) {
+	mu2.compileAndRender(filename, options).on('data', function(data) {
 		result += data;
 	}).on('end', function() {
 		fn(null, result);


### PR DESCRIPTION
Fixed supplying data into the view in recent version of
Express.,mu2.root is set according to views directory so mustache can
find partials.
