### PR TITLE
Fixed package name casing error in the README example code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ mu2Express is a small node module with an express template engine function for t
 Example:
 
 ```javascript
-var mu2Express = require("mu2Express");
+var mu2Express = require("mu2express");
 var express = require("express");
 var app = express();
 app.engine('mustache', mu2Express.engine);


### PR DESCRIPTION
Since the package.json name is all lowercase, the require() function should require 'mu2express', all lowercase.
Also see: http://stackoverflow.com/questions/15053102/mustache-and-express-in-node
